### PR TITLE
Add enums and records support

### DIFF
--- a/src/main/java/group/aelysium/declarative_yaml/DeclarativeYAML.java
+++ b/src/main/java/group/aelysium/declarative_yaml/DeclarativeYAML.java
@@ -57,20 +57,21 @@ public class DeclarativeYAML {
      * When adding comments using the {@link Comment} annotation, you can define targets as {some_key} which will be replaced when the config is generated.
      * <pre><code>{@code "This is an example comment with an inserted value that says: {say_something_here}" }</code></pre>
      * To replace a target, you can define its name inside the commentReplacements parameter on {@link Printer}.
-     * @param clazz The class definition of the config.
+     *
+     * @param clazz   The class definition of the config.
      * @param printer The printer configuration to use.
-     * @throws IOException If the config filepath contains invalid characters.
+     * @throws IOException                    If the config filepath contains invalid characters.
      * @throws ArrayIndexOutOfBoundsException If you don't provide the same number of pathReplacements as {path_parameters} in the @Config path.
      */
     public static <T> T load(@NotNull Class<T> clazz, @NotNull Printer printer) throws IOException, ArrayIndexOutOfBoundsException {
         printer.injecting(clazz.isAnnotationPresent(Inject.class));
 
-        if(!(clazz.isAnnotationPresent(Config.class) || !printer.injecting()))
+        if (!(clazz.isAnnotationPresent(Config.class) || !printer.injecting()))
             throw new RuntimeException("Config class declarations must be annotated with either @Config or @Inject.");
 
         String configPath;
         {
-            if(printer.injecting()) configPath = clazz.getAnnotation(Inject.class).value();
+            if (printer.injecting()) configPath = clazz.getAnnotation(Inject.class).value();
             else configPath = clazz.getAnnotation(Config.class).value();
         }
 
@@ -87,7 +88,7 @@ public class DeclarativeYAML {
 
             handleAllContents(clazz, instance, path);
             for (ConfigTarget target : targets) {
-                if(target.field() == null) continue;
+                if (target.field() == null) continue;
                 target.field().setAccessible(true);
                 target.field().set(instance, getValueFromYAML(yaml, target));
                 target.field().setAccessible(false);
@@ -109,31 +110,33 @@ public class DeclarativeYAML {
                 .forEach(f -> {
                     boolean hasComment = f.isAnnotationPresent(Comment.class);
                     boolean hasEntry = f.isAnnotationPresent(Node.class);
-                    if(!(hasComment || hasEntry)) return;
+                    if (!(hasComment || hasEntry)) return;
 
                     Node node = f.getAnnotation(Node.class);
 
                     List<String> comment = null;
-                    if(hasComment) {
+                    if (hasComment) {
                         Comment c = f.getAnnotation(Comment.class);
                         comment = new ArrayList<>();
                         for (String s : c.value()) {
                             AtomicReference<String> correctedString = new AtomicReference<>(s);
-                            printer.commentReplacements().forEach((k, v) -> correctedString.set(correctedString.get().replace("{"+k+"}", v)));
+                            printer.commentReplacements().forEach((k, v) -> correctedString.set(correctedString.get().replace("{" + k + "}", v)));
                             comment.add(correctedString.get());
                         }
                     }
 
                     String key = node.key();
-                    if(key.isEmpty()) key = FieldAssigner.convertFieldNameToYAMLKey(f);
+                    if (key.isEmpty()) key = FieldAssigner.convertFieldNameToYAMLKey(f);
 
                     Object defaultValue = null;
                     try {
                         f.setAccessible(true);
                         defaultValue = f.get(instance);
                         f.setAccessible(false);
-                    } catch (Exception ignore) {}
-                    if(defaultValue == null) throw new NullPointerException("You must define a default value on fields annotated with @Node. Issue was caused by "+ f.getName());
+                    } catch (Exception ignore) {
+                    }
+                    if (defaultValue == null)
+                        throw new NullPointerException("You must define a default value on fields annotated with @Node. Issue was caused by " + f.getName());
                     targets.add(new ConfigTarget(node.value(), key, defaultValue, f, comment));
                 });
 
@@ -166,10 +169,10 @@ public class DeclarativeYAML {
                 YAMLNode newCurrent = currentNode.get().setGetChild(
                         key,
                         lastKey ? new YAMLNode(key, parsingTarget.value(), parsingTarget.comment())
-                        : new YAMLNode(key, null)
+                                : new YAMLNode(key, null)
                 );
-                if(Set.class.isAssignableFrom(parsingTarget.value().getClass())) newCurrent.isArray(true);
-                if(List.class.isAssignableFrom(parsingTarget.value().getClass())) newCurrent.isArray(true);
+                if (Set.class.isAssignableFrom(parsingTarget.value().getClass())) newCurrent.isArray(true);
+                if (List.class.isAssignableFrom(parsingTarget.value().getClass())) newCurrent.isArray(true);
 
                 currentNode.set(newCurrent);
             }
@@ -182,7 +185,7 @@ public class DeclarativeYAML {
         Arrays.stream(clazz.getDeclaredFields())
                 .filter(f -> !Modifier.isStatic(f.getModifiers())).toList()
                 .forEach(f -> {
-                    if(!f.isAnnotationPresent(PathParameter.class)) return;
+                    if (!f.isAnnotationPresent(PathParameter.class)) return;
 
                     PathParameter pathParameter = f.getAnnotation(PathParameter.class);
                     try {
@@ -202,10 +205,11 @@ public class DeclarativeYAML {
         Arrays.stream(clazz.getDeclaredFields())
                 .filter(f -> !Modifier.isStatic(f.getModifiers())).toList()
                 .forEach(f -> {
-                    if(!f.isAnnotationPresent(AllContents.class)) return;
+                    if (!f.isAnnotationPresent(AllContents.class)) return;
 
                     try {
-                        if (!f.getType().equals(byte[].class)) throw new ClassCastException("Fields annotated with @AllContents must be of type byte[]!");
+                        if (!f.getType().equals(byte[].class))
+                            throw new ClassCastException("Fields annotated with @AllContents must be of type byte[]!");
 
                         f.setAccessible(true);
                         f.set(instance, allContents);
@@ -218,6 +222,7 @@ public class DeclarativeYAML {
 
     /**
      * Retrieve data from a specific configuration node.
+     *
      * @param target The target to search for.
      * @return Data with a type matching `type`
      * @throws IllegalStateException If there was an issue while retrieving the data or converting it to `type`.
@@ -243,19 +248,20 @@ public class DeclarativeYAML {
 
         try {
             if (!configPointer.exists()) {
-                if(printer.injecting()) throw new IOException("Attempted to inject into a config that doesn't exist! "+path);
+                if (printer.injecting())
+                    throw new IOException("Attempted to inject into a config that doesn't exist! " + path);
 
                 File parent = configPointer.getParentFile();
-                if(parent != null) if (!parent.exists()) parent.mkdirs();
+                if (parent != null) if (!parent.exists()) parent.mkdirs();
                 configPointer.createNewFile();
 
-                try(FileWriter writer = new FileWriter(configPointer)) {
+                try (FileWriter writer = new FileWriter(configPointer)) {
                     YAMLPrinter.deserialize(writer, nodeTree, printer);
                 }
             }
 
-            if(printer.injecting()) {
-                try(FileWriter writer = new FileWriter(configPointer)) {
+            if (printer.injecting()) {
+                try (FileWriter writer = new FileWriter(configPointer)) {
                     YAMLPrinter.deserialize(writer, nodeTree, printer);
                 }
             }
@@ -274,18 +280,19 @@ public class DeclarativeYAML {
         {
             AtomicInteger index = new AtomicInteger(0);
             List<String> splitPath = Arrays.stream(originalPath.split("/")).map(v -> {
-                if(!v.startsWith("{")) return v;
-                String key = v.replaceAll("^.*\\{([a-zA-Z0-9\\_\\-\\.\\/\\\\]+)\\}.*","$1");
+                if (!v.startsWith("{")) return v;
+                String key = v.replaceAll("^.*\\{([a-zA-Z0-9\\_\\-\\.\\/\\\\]+)\\}.*", "$1");
 
                 String replacement = printer.pathReplacements().get(key);
-                if(replacement == null) throw new IllegalArgumentException("No value for the path key '"+key+"' exists!");
+                if (replacement == null)
+                    throw new IllegalArgumentException("No value for the path key '" + key + "' exists!");
                 index.incrementAndGet();
-                return v.replaceAll("^\\{[a-zA-Z0-9\\_\\-\\.\\/\\\\]+\\}(\\.[a-zA-Z0-9\\_\\-]*)?",replacement+"$1");
+                return v.replaceAll("^\\{[a-zA-Z0-9\\_\\-\\.\\/\\\\]+\\}(\\.[a-zA-Z0-9\\_\\-]*)?", replacement + "$1");
             }).toList();
             path = String.join("/", splitPath);
         }
-        if(!Pattern.compile("^[a-zA-Z0-9\\_\\-\\.\\/\\\\]+$").matcher(path).matches())
-            throw new IOException("Invalid file path defined for config: "+path);
+        if (!Pattern.compile("^[a-zA-Z0-9\\_\\-\\.\\/\\\\]+$").matcher(path).matches())
+            throw new IOException("Invalid file path defined for config: " + path);
 
         return path;
     }
@@ -301,7 +308,7 @@ class YAMLPrinter {
 
         // Climb hierarchy
         if (current.children().isPresent()) {
-            if(current.name() == null) {
+            if (current.name() == null) {
                 for (YAMLNode node : current.children().orElseThrow())
                     nodeToString(writer, node, level, printer);
                 return;
@@ -318,32 +325,32 @@ class YAMLPrinter {
             if (printer.indentComments()) writer.append(indent);
 
             // Add comment hashtag if one wasn't given.
-            if(!s.startsWith("#")) writer.append("# ");
+            if (!s.startsWith("#")) writer.append("# ");
 
             writer.append(s);
             writer.append("\n");
         }
 
         // Print Node
-        if(current.value().isEmpty()) return;
+        if (current.value().isEmpty()) return;
         Object value = current.value().orElseThrow();
         Class<?> clazz = value.getClass();
 
-        if(current.name() != null) writer.append(indent).append(current.name()).append(": ");
+        if (current.name() != null) writer.append(indent).append(current.name()).append(": ");
 
-        if(Primitives.isPrimitive(clazz) || value instanceof String) {
+        if (Primitives.isPrimitive(clazz) || value instanceof String) {
             writer.append(current.stringifiedValue().orElse("")).append("\n");
             writer.append(printer.lineSeparator());
         }
 
-        if(Serializable.class.isAssignableFrom(clazz)) {
+        if (Serializable.class.isAssignableFrom(clazz)) {
             List<Field> fields = Arrays.stream(clazz.getFields()).filter(f -> !Modifier.isStatic(f.getModifiers())).toList();
 
             YAMLNode extraNode = new YAMLNode(null, null);
             boolean hasEntries = false;
             for (Field f : fields) {
                 f.setAccessible(true);
-                if(f.get(value) == null) {
+                if (f.get(value) == null) {
                     f.setAccessible(false);
                     continue;
                 }
@@ -352,12 +359,12 @@ class YAMLPrinter {
                 hasEntries = true;
                 f.setAccessible(false);
             }
-            if(!hasEntries) {
+            if (!hasEntries) {
                 writer.append("{}\n");
                 writer.append(printer.lineSeparator());
                 return;
             }
-            if(current.name() != null) writer.append("\n");
+            if (current.name() != null) writer.append("\n");
             nodeToString(writer, extraNode, level + 1, printer);
 
             writer.append(printer.lineSeparator());
@@ -368,8 +375,48 @@ class YAMLPrinter {
             writer.append(printer.lineSeparator());
         }
 
-        if(Collection.class.isAssignableFrom(clazz)) {
-            if(((Collection<?>) value).isEmpty()) {
+        if (Record.class.isAssignableFrom(clazz)) {
+            List<RecordComponent> components = Arrays.stream(clazz.getRecordComponents()).toList();
+            YAMLNode extraNode = new YAMLNode(null, null);
+            boolean hasEntries = false;
+            for (RecordComponent component : components) {
+                Method accessor = component.getAccessor();
+                Object componentValue = accessor.invoke(value);
+                if (componentValue == null) {
+                    continue;
+                }
+
+                List<String> comment = null;
+                boolean hasComment = component.isAnnotationPresent(Comment.class);
+                if (hasComment) {
+                    Comment c = component.getAnnotation(Comment.class);
+                    comment = new ArrayList<>();
+                    for (String s : c.value()) {
+                        AtomicReference<String> correctedString = new AtomicReference<>(s);
+                        printer.commentReplacements().forEach((k, v) -> correctedString.set(correctedString.get().replace("{" + k + "}", v)));
+                        comment.add(correctedString.get());
+                    }
+                }
+
+                String name = FieldAssigner.convertFieldNameToYAMLKey(component.getName());
+                extraNode.setGetChild(name, new YAMLNode(name, componentValue, comment));
+                hasEntries = true;
+            }
+
+            if (!hasEntries) {
+                writer.append("{}\n");
+                writer.append(printer.lineSeparator());
+                return;
+            }
+
+            if (current.name() != null) writer.append("\n");
+            nodeToString(writer, extraNode, level + 1, printer);
+
+            writer.append(printer.lineSeparator());
+        }
+
+        if (Collection.class.isAssignableFrom(clazz)) {
+            if (((Collection<?>) value).isEmpty()) {
                 writer.append("[]\n");
                 writer.append(printer.lineSeparator());
                 return;
@@ -377,45 +424,44 @@ class YAMLPrinter {
 
             writer.append("\n");
             for (Object e : (Collection<?>) value) {
-                if(Primitives.isPrimitive(e.getClass())) {
+                if (Primitives.isPrimitive(e.getClass())) {
                     writer.append("\n");
                     writer.append(indent).append(Strings.repeat(" ", printer.indentSpaces())).append("- ").append(e.toString());
-                } else if(e instanceof String) {
+                } else if (e instanceof String) {
                     writer.append("\n");
                     writer.append(indent).append(Strings.repeat(" ", printer.indentSpaces())).append("- \"").append(String.valueOf(e)).append("\"");
-                } else if(e instanceof Serializable) {
+                } else if (e instanceof Serializable) {
                     writer.append(indent).append(Strings.repeat(" ", printer.indentSpaces())).append("- ");
                     String tempLineSeparator = printer.lineSeparator();
                     printer.lineSeparator("");
                     nodeToString(writer, new YAMLNode(null, e, null), level, printer);
                     printer.lineSeparator(tempLineSeparator);
-                }
-                else continue;
+                } else continue;
                 writer.append("\n");
             }
             writer.append(printer.lineSeparator());
         }
 
-        if(Map.class.isAssignableFrom(value.getClass())) {
-            if(((Map<?,?>) value).isEmpty()) {
+        if (Map.class.isAssignableFrom(value.getClass())) {
+            if (((Map<?, ?>) value).isEmpty()) {
                 writer.append("{}\n");
                 writer.append(printer.lineSeparator());
                 return;
             }
 
             YAMLNode tempNode = new YAMLNode(null, null);
-            ((Map<?, ?>) value).forEach((k, v)->{
+            ((Map<?, ?>) value).forEach((k, v) -> {
                 Class<?> valueClass = v.getClass();
 
-                if(!(k instanceof String key))
-                    throw new RuntimeException("Declarative YAML requires that maps conform to one of the supported types: ["+FieldAssigner.supportedMaps+"]");
-                if(!(Primitives.isPrimitive(clazz) || String.class.isAssignableFrom(valueClass) || Serializable.class.isAssignableFrom(valueClass)))
-                    throw new RuntimeException("Declarative YAML requires that maps conform to one of the supported types: ["+FieldAssigner.supportedMaps+"]");
+                if (!(k instanceof String key))
+                    throw new RuntimeException("Declarative YAML requires that maps conform to one of the supported types: [" + FieldAssigner.supportedMaps + "]");
+                if (!(Primitives.isPrimitive(clazz) || String.class.isAssignableFrom(valueClass) || Serializable.class.isAssignableFrom(valueClass)))
+                    throw new RuntimeException("Declarative YAML requires that maps conform to one of the supported types: [" + FieldAssigner.supportedMaps + "]");
 
                 tempNode.setGetChild(FieldAssigner.convertFieldNameToYAMLKey(key), new YAMLNode(FieldAssigner.convertFieldNameToYAMLKey(key), v, null));
             });
 
-            if(current.name() != null) writer.append("\n");
+            if (current.name() != null) writer.append("\n");
             nodeToString(writer, tempNode, level + 1, printer);
         }
     }

--- a/src/main/java/group/aelysium/declarative_yaml/DeclarativeYAML.java
+++ b/src/main/java/group/aelysium/declarative_yaml/DeclarativeYAML.java
@@ -335,6 +335,7 @@ class YAMLPrinter {
             writer.append(current.stringifiedValue().orElse("")).append("\n");
             writer.append(printer.lineSeparator());
         }
+
         if(Serializable.class.isAssignableFrom(clazz)) {
             List<Field> fields = Arrays.stream(clazz.getFields()).filter(f -> !Modifier.isStatic(f.getModifiers())).toList();
 
@@ -361,6 +362,12 @@ class YAMLPrinter {
 
             writer.append(printer.lineSeparator());
         }
+
+        if (clazz.isEnum()) {
+            writer.append(value.toString());
+            writer.append(printer.lineSeparator());
+        }
+
         if(Collection.class.isAssignableFrom(clazz)) {
             if(((Collection<?>) value).isEmpty()) {
                 writer.append("[]\n");
@@ -388,6 +395,7 @@ class YAMLPrinter {
             }
             writer.append(printer.lineSeparator());
         }
+
         if(Map.class.isAssignableFrom(value.getClass())) {
             if(((Map<?,?>) value).isEmpty()) {
                 writer.append("{}\n");

--- a/src/main/java/group/aelysium/declarative_yaml/FieldAssigner.java
+++ b/src/main/java/group/aelysium/declarative_yaml/FieldAssigner.java
@@ -20,6 +20,7 @@ class FieldAssigner {
             "String",
             "Serializable",
             "Enums",
+            "Java Records",
             "List<Primitive>",
             "List<String>",
             "List<Serializable",

--- a/src/main/java/group/aelysium/declarative_yaml/FieldAssigner.java
+++ b/src/main/java/group/aelysium/declarative_yaml/FieldAssigner.java
@@ -30,27 +30,33 @@ class FieldAssigner {
     ));
 
     public static Object serialize(CommentedConfigurationNode node, Class<?> clazz, Type type) throws Exception {
-        if(Primitives.isPrimitive(clazz)) return FieldAssigner.serializePrimitive(node, clazz);
-        if(String.class.isAssignableFrom(clazz)) return FieldAssigner.serializeString(node);
-        if(Serializable.class.isAssignableFrom(clazz)) return FieldAssigner.serializeObject(node, clazz);
+        if (Primitives.isPrimitive(clazz)) return FieldAssigner.serializePrimitive(node, clazz);
+        if (String.class.isAssignableFrom(clazz)) return FieldAssigner.serializeString(node);
+        if (Serializable.class.isAssignableFrom(clazz)) return FieldAssigner.serializeObject(node, clazz);
         if (clazz.isEnum()) {
             @SuppressWarnings("unchecked") final var enumType = (Class<? extends Enum<?>>) clazz;
             return FieldAssigner.serializeEnum(node, enumType);
         }
+        if (Record.class.isAssignableFrom(clazz)) return FieldAssigner.serializeRecord(node, clazz);
 
-        if(!(type instanceof ParameterizedType parameterizedType))
-            throw new RuntimeException(clazz.getSimpleName()+" is not a type that's supported by Declarative YAML. Supported types are: "+supportedTypes);
+        if (!(type instanceof ParameterizedType parameterizedType))
+            throw new RuntimeException(clazz.getSimpleName() + " is not a type that's supported by Declarative YAML. Supported types are: " + supportedTypes);
 
-        if(List.class.isAssignableFrom(clazz) && node.isList()) return FieldAssigner.serializeList(node, clazz, parameterizedType);
-        if(Set.class.isAssignableFrom(clazz) && node.isList()) return FieldAssigner.serializeSet(node, clazz, parameterizedType);
-        if(Map.class.isAssignableFrom(clazz) && node.isMap()) return FieldAssigner.serializeMap(node, clazz, parameterizedType);
+        if (List.class.isAssignableFrom(clazz) && node.isList())
+            return FieldAssigner.serializeList(node, clazz, parameterizedType);
+        if (Set.class.isAssignableFrom(clazz) && node.isList())
+            return FieldAssigner.serializeSet(node, clazz, parameterizedType);
+        if (Map.class.isAssignableFrom(clazz) && node.isMap())
+            return FieldAssigner.serializeMap(node, clazz, parameterizedType);
 
-        throw new RuntimeException(clazz.getSimpleName()+" is not a type that's supported by Declarative YAML. Supported types are: "+supportedTypes);
+        throw new RuntimeException(clazz.getSimpleName() + " is not a type that's supported by Declarative YAML. Supported types are: " + supportedTypes);
     }
+
 
     private static <T> T serializePrimitive(CommentedConfigurationNode node, Class<T> clazz) throws Exception {
         return node.get(clazz);
     }
+
     private static String serializeString(CommentedConfigurationNode node) {
         return node.getString();
     }
@@ -72,7 +78,7 @@ class FieldAssigner {
                     CommentedConfigurationNode node = DeclarativeYAML.getNodeFromYAML(objectRoot, key);
                     f.set(instance, serialize(node, f.getType(), f.getGenericType()));
                 } catch (Exception e) {
-                    if(isOptional) {
+                    if (isOptional) {
                         f.set(instance, null);
                         f.setAccessible(false);
                         continue;
@@ -90,7 +96,7 @@ class FieldAssigner {
         }
     }
 
-    private static Object serializeEnum(CommentedConfigurationNode node, Class<?extends Enum<?>> clazz) {
+    private static Object serializeEnum(CommentedConfigurationNode node, Class<? extends Enum<?>> clazz) {
         String value = node.getString();
 
         if (value == null || value.isBlank()) {
@@ -105,45 +111,72 @@ class FieldAssigner {
         }
     }
 
+    private static Object serializeRecord(CommentedConfigurationNode node, Class<?> clazz) throws Exception {
+        RecordComponent[] components = clazz.getRecordComponents();
+        Map<String, Object> values = new HashMap<>();
+
+        for (RecordComponent component : components) {
+            String key = FieldAssigner.convertFieldNameToYAMLKey(component.getName());
+            CommentedConfigurationNode componentNode = node.node(key);
+            values.put(component.getName(), FieldAssigner.serialize(componentNode, component.getType(), component.getGenericType()));
+        }
+
+        Object[] valuesArray = Arrays.stream(components)
+                .map(component -> values.get(component.getName()))
+                .toArray();
+
+        Constructor<?> constructor = clazz.getDeclaredConstructor(
+                Arrays.stream(components).map(RecordComponent::getType).toArray(Class<?>[]::new)
+        );
+        constructor.setAccessible(true);
+        Object instance = constructor.newInstance(valuesArray);
+        constructor.setAccessible(false);
+
+        return instance;
+    }
+
     private static List<Object> serializeList(CommentedConfigurationNode node, Class<?> clazz, ParameterizedType type) throws Exception {
         Type entryType = type.getActualTypeArguments()[0];
         Class<?> entryClass = (Class<?>) type.getActualTypeArguments()[0];
 
-        if(!(Primitives.isPrimitive(entryClass) || String.class.isAssignableFrom(entryClass) || Serializable.class.isAssignableFrom(entryClass)))
-            throw new ClassCastException(clazz.getSimpleName()+" isn't a supported type in Declarative YAML. The supported types are: "+supportedTypes);
+        if (!(Primitives.isPrimitive(entryClass) || String.class.isAssignableFrom(entryClass) || Serializable.class.isAssignableFrom(entryClass)))
+            throw new ClassCastException(clazz.getSimpleName() + " isn't a supported type in Declarative YAML. The supported types are: " + supportedTypes);
 
         List<Object> list = new ArrayList<>();
         for (CommentedConfigurationNode entry : node.childrenList())
             list.add(serialize(entry, entryClass, entryType));
         return list;
     }
+
     private static Set<Object> serializeSet(CommentedConfigurationNode node, Class<?> clazz, ParameterizedType type) throws Exception {
         Type entryType = type.getActualTypeArguments()[0];
         Class<?> entryClass = (Class<?>) type.getActualTypeArguments()[0];
 
-        if(!(Primitives.isPrimitive(entryClass) || String.class.isAssignableFrom(entryClass) || Serializable.class.isAssignableFrom(entryClass)))
-            throw new ClassCastException(clazz.getSimpleName()+" isn't a supported type in Declarative YAML. The supported types are: "+supportedTypes);
+        if (!(Primitives.isPrimitive(entryClass) || String.class.isAssignableFrom(entryClass) || Serializable.class.isAssignableFrom(entryClass)))
+            throw new ClassCastException(clazz.getSimpleName() + " isn't a supported type in Declarative YAML. The supported types are: " + supportedTypes);
 
         Set<Object> set = new HashSet<>();
         for (CommentedConfigurationNode entry : node.childrenList())
             set.add(serialize(entry, entryClass, entryType));
         return set;
     }
+
     private static Map<String, ?> serializeMap(CommentedConfigurationNode node, Class<?> clazz, ParameterizedType type) throws Exception {
         Type keyType = type.getActualTypeArguments()[0];
         Type valueType = type.getActualTypeArguments()[1];
         Class<?> keyClass = (Class<?>) type.getActualTypeArguments()[0];
         Class<?> valueClass = (Class<?>) type.getActualTypeArguments()[1];
 
-        if(!(String.class.isAssignableFrom(keyClass)))
-            throw new ClassCastException(clazz.getSimpleName()+" isn't a supported type in Declarative YAML. The supported types are: "+supportedTypes);
-        if(!(Primitives.isPrimitive(valueClass) || String.class.isAssignableFrom(valueClass) || Serializable.class.isAssignableFrom(valueClass)))
-            throw new ClassCastException(clazz.getSimpleName()+" isn't a supported type in Declarative YAML. The supported types are: "+supportedTypes);
+        if (!(String.class.isAssignableFrom(keyClass)))
+            throw new ClassCastException(clazz.getSimpleName() + " isn't a supported type in Declarative YAML. The supported types are: " + supportedTypes);
+        if (!(Primitives.isPrimitive(valueClass) || String.class.isAssignableFrom(valueClass) || Serializable.class.isAssignableFrom(valueClass)))
+            throw new ClassCastException(clazz.getSimpleName() + " isn't a supported type in Declarative YAML. The supported types are: " + supportedTypes);
 
         Map<String, Object> map = new HashMap<>();
 
         for (Map.Entry<Object, CommentedConfigurationNode> entry : node.childrenMap().entrySet()) {
-            if(!(entry.getKey() instanceof String key)) throw new IllegalArgumentException("Declarative YAML requires that maps loaded from YAML must be of the type ["+supportedMaps+"].");
+            if (!(entry.getKey() instanceof String key))
+                throw new IllegalArgumentException("Declarative YAML requires that maps loaded from YAML must be of the type [" + supportedMaps + "].");
 
             map.put(key, serialize(entry.getValue(), valueClass, valueType));
         }
@@ -154,6 +187,7 @@ class FieldAssigner {
     public static String convertFieldNameToYAMLKey(String name) {
         return String.join(".", Arrays.stream(name.split("_")).map(s -> s.replaceAll("([a-z])([A-Z]+)", "$1-$2").toLowerCase()).toList());
     }
+
     public static String convertFieldNameToYAMLKey(Field field) {
         return convertFieldNameToYAMLKey(field.getName());
     }

--- a/src/main/java/group/aelysium/declarative_yaml/annotations/Comment.java
+++ b/src/main/java/group/aelysium/declarative_yaml/annotations/Comment.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
  * Comments only work if they're added to an already existing {@link Node}.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD, ElementType.TYPE })
+@Target({ElementType.FIELD, ElementType.TYPE, ElementType.RECORD_COMPONENT})
 public @interface Comment {
     /**
      * The comment to show.


### PR DESCRIPTION
This PR adds support for Java Enums and Records
Config Class:
```java
@Config("config.yml")
    public class DefaultConfig {
        @Node
        public User user = new User("test", UserType.ADMIN);

        public record User(String username, @Comment("USER, ADMIN") UserType type) {}

        public enum UserType {
            USER, ADMIN
        }

        public static DefaultConfig load() throws IOException {
            return DeclarativeYAML.load(DefaultConfig.class);
        }
    }
```

Generated config file:
```yaml
user: 
    username: "test"
    # USER, ADMIN
    type: ADMIN
```

Test:
```java
    public static void main(String[] args) {
        DefaultConfig config;
        try {
            config = DefaultConfig.load();
            System.out.println(config.user);
        } catch (IOException e) {
            throw new RuntimeException(e);
        }
    }
```
returns: ```User[username=meow, type=ADMIN]```